### PR TITLE
PID controllers in hand

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,4 +37,4 @@ add_subdirectory(grasp)
 add_subdirectory(utils)
 
 # Documentation
-# add_subdirectory(doc)
+add_subdirectory(doc)

--- a/models/vizzy_right_hand.urdf
+++ b/models/vizzy_right_hand.urdf
@@ -250,7 +250,8 @@
     <parent link="r_hand_base_link"/>
     <child link="r_min_phal_1_link"/>
     <axis xyz="1 0 0"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_min_phal_1_link_fix">
     <inertial>
@@ -307,7 +308,8 @@
     <parent link="r_min_phal_1_link"/>
     <child link="r_min_phal_2_link"/>
     <axis xyz="0 0 1"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_min_phal_2_link_fix">
     <inertial>
@@ -364,7 +366,8 @@
     <parent link="r_min_phal_2_link"/>
     <child link="r_min_phal_3_link"/>
     <axis xyz="0 0 1"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_min_phal_3_link_fix">
     <inertial>
@@ -421,7 +424,8 @@
     <parent link="r_hand_base_link"/>
     <child link="r_med_phal_1_link"/>
     <axis xyz="1 0 0"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_med_phal_1_link_fix">
     <inertial>
@@ -478,7 +482,8 @@
     <parent link="r_med_phal_1_link"/>
     <child link="r_med_phal_2_link"/>
     <axis xyz="0 0 1"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_med_phal_2_link_fix">
     <inertial>
@@ -535,7 +540,8 @@
     <parent link="r_med_phal_2_link"/>
     <child link="r_med_phal_3_link"/>
     <axis xyz="0 0 1"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_med_phal_3_link_fix">
     <inertial>
@@ -592,7 +598,8 @@
     <parent link="r_hand_base_link"/>
     <child link="r_ind_phal_1_link"/>
     <axis xyz="1 0 0"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_ind_phal_1_link_fix">
     <inertial>
@@ -649,7 +656,8 @@
     <parent link="r_ind_phal_1_link"/>
     <child link="r_ind_phal_2_link"/>
     <axis xyz="0 0 1"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_ind_phal_2_link_fix">
     <inertial>
@@ -706,7 +714,8 @@
     <parent link="r_ind_phal_2_link"/>
     <child link="r_ind_phal_3_link"/>
     <axis xyz="0 0 1"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_ind_phal_3_link_fix">
     <inertial>
@@ -763,7 +772,8 @@
     <parent link="r_hand_base_link"/>
     <child link="r_thumb_phal_1_link"/>
     <axis xyz="0 0 1"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_thumb_phal_1_link_fix">
     <inertial>
@@ -820,7 +830,8 @@
     <parent link="r_thumb_phal_1_link"/>
     <child link="r_thumb_phal_2_link"/>
     <axis xyz="1 0 0"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_thumb_phal_2_link_fix">
     <inertial>
@@ -855,7 +866,8 @@
     <parent link="r_thumb_phal_2_link"/>
     <child link="r_thumb_phal_3_link"/>
     <axis xyz="0 0 1"/>
-    <limit effort="0" lower="0" upper="1.57" velocity="0"/>
+    <limit lower="0.0" upper="1.57" effort="2.11" velocity="2.11" />
+    <dynamics damping="0.1" />
   </joint>
   <link name="r_thumb_phal_3_link">
     <inertial>

--- a/plugins/ConcurrentQueue.hh
+++ b/plugins/ConcurrentQueue.hh
@@ -2,9 +2,10 @@
     \file plugins/ConcurrentQueue.hh
     \brief Queue data structure for concurrent access
 
-    Naive queue data structure for correct concurrent access and decent performance.
     Heavily inspired in
-    <a href="https://gist.github.com/dpressel/de9ea7603fa3f20b55bf">this gist</a>
+    <a href="https://gist.github.com/dpressel/de9ea7603fa3f20b55bf">
+        this gist
+    </a>.
 */
 
 #ifndef __CONCURRENT_QUEUE_H__
@@ -14,13 +15,16 @@
 #include <mutex>
 #include <condition_variable>
 #include <chrono>
-using namespace std::chrono_literals;
 
 template<typename T>
 
 /// \brief FIFO queue for threadsafe access
 ///
-/// Generic concurrent access queue for consumer-producer scenario
+/// Generic concurrent access queue for consumer-producer scenario.
+/// Heavily inspired in
+/// <a href="https://gist.github.com/dpressel/de9ea7603fa3f20b55bf">
+///     this gist
+/// </a>.
 class ConcurrentQueue
 {
     /// Condition variable
@@ -43,8 +47,9 @@ class ConcurrentQueue
     public: bool enqueue(T data)
     {
         bool success = false;
+        std::chrono::milliseconds timeout(200);
         std::unique_lock<std::mutex> lock(mutex);
-        if (cond_var.wait_for(lock, 200ms, [this](){ return !isFull();}))
+        if (cond_var.wait_for(lock, timeout, [this](){ return !isFull();}))
         {
             queue.push(data);
             success = true;
@@ -60,8 +65,9 @@ class ConcurrentQueue
     public: bool dequeue(T &data)
     {
         bool success = false;
+        std::chrono::milliseconds timeout(200);
         std::unique_lock<std::mutex> lock(mutex);
-        if (cond_var.wait_for(lock, 200ms, [this](){ return !isEmpty();}))
+        if (cond_var.wait_for(lock, timeout, [this](){ return !isEmpty();}))
         {
             data = queue.front();
             queue.pop();

--- a/plugins/HandPlugin.hh
+++ b/plugins/HandPlugin.hh
@@ -80,9 +80,6 @@ namespace gazebo {
         /// Array of virtual x y z r p y joint pointers
         private: std::vector<physics::JointPtr> virtual_joints;
 
-        /// PID controllers for virtual joints
-        private: std::vector<common::PID> pid_controllers;
-
         /// Timeout trigger
         private: bool timer_active {false};
         /// Next timeout
@@ -102,11 +99,6 @@ namespace gazebo {
         private: bool update_joint_velocities       {false};
         /// Flag to reset
         private: bool reset                         {false};
-
-        /// Update rate value in physics engine iterations
-        private: uint32_t update_rate               {5};
-        /// Last updated
-        private: uint32_t last_updated              {0};
 
         // Protected attributes
 
@@ -132,6 +124,7 @@ namespace gazebo {
 
         // Private methods
 
+        /// TODO
         private: bool loadMimicJoints(sdf::ElementPtr _sdf, JointGroup & joint);
 
         /// \brief Loads finger joints

--- a/utils/hand_remote.cc
+++ b/utils/hand_remote.cc
@@ -37,7 +37,7 @@ int main(int _argc, char **_argv)
         // Change pose request
         if (command == "pose")
         {
-            ignition::math::Pose3d pose(0.07,0.12,0.1,0,1.57,0);
+            ignition::math::Pose3d pose(0,0.0,0.1,0,1.57,0);
             setPose(pub, pose);
         }
         // Change velocity request
@@ -49,7 +49,7 @@ int main(int _argc, char **_argv)
         // Close hand
         else if (command == "close")
         {
-            std::vector<double> velocities_close {6,6,6};
+            std::vector<double> velocities_close {1.56,1.56,1.56};
             std::vector<double> velocity {0,0,0,0,0,0};
             setJointVelocities(pub, velocities_close);
             setVelocity(pub, velocity);
@@ -121,16 +121,16 @@ void reset(gazebo::transport::PublisherPtr pub)
 /////////////////////////////////////////////////
 void tryGrasp(gazebo::transport::PublisherPtr pub)
 {
-    ignition::math::Pose3d pose(0.07,0.12,0.1,0,1.57,0);
-    std::vector<double> velocity_lift {0,0,20,0,0,0};
+    ignition::math::Pose3d pose(0,0,0.1,0,1.57,0);
+    std::vector<double> velocity_lift {0,0,10,0,0,0};
     std::vector<double> velocity_stop {0,0,0,0,0,0};
-    std::vector<double> velocities_close {8,8,8};
+    std::vector<double> velocities_close {1.56,1.56,1.56};
     std::vector<double> velocities_open {0,0,0};
 
     setPose(pub, pose);
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    setJointVelocities(pub, velocities_close);
     setVelocity(pub, velocity_stop);
+    setJointVelocities(pub, velocities_close);
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     setVelocity(pub, velocity_lift);
     std::this_thread::sleep_for(std::chrono::milliseconds(3000));

--- a/worlds/dart.world
+++ b/worlds/dart.world
@@ -4,6 +4,13 @@
 
     <physics type="dart">
       <real_time_update_rate>0.000000</real_time_update_rate>
+      <!--
+      <dart>
+        <solver>
+          <solver_type>pgs</solver_type>
+        </solver>
+      </dart>
+      -->
     </physics>
 
     <include>


### PR DESCRIPTION
Added pid controllers to hand plugin, for both virtual and finger joints.
The former allow the hand to be stable in mid-air while moving the fingers.
Fingers are controlled with position PIDs, and emulate underactuated fingers more precisely.